### PR TITLE
Make Get-Command call silent when it fails

### DIFF
--- a/Cackledaemon.org
+++ b/Cackledaemon.org
@@ -360,7 +360,7 @@ will prompt for these elevated privileges when necessary.
 Write-Host "Checking the state of Emacs..."
 Write-Host ''
 
-$EmacsCommand = Get-Command 'emacs.exe'
+$EmacsCommand = Get-Command 'emacs.exe' -ErrorAction 'silentlyContinue'
 
 if ($EmacsCommand) {
   if (Test-EmacsExe -ErrorAction Stop) {
@@ -3924,6 +3924,8 @@ task Publish Build, Test, {
 #+END_SRC
 
 * ChangeLog :export:
+** Master
+- ~Get-Command~ call in install wizard is now silent when Emacs isn't installed
 ** 2020-05-11 Release v0.1.1
 - Copy edits to the introduction
 - A link to the release announcement blog post

--- a/InstallWizard.ps1
+++ b/InstallWizard.ps1
@@ -128,7 +128,7 @@ if (Test-Path $CackledaemonWD) {
 Write-Host "Checking the state of Emacs..."
 Write-Host ''
 
-$EmacsCommand = Get-Command 'emacs.exe'
+$EmacsCommand = Get-Command 'emacs.exe' -ErrorAction 'silentlyContinue'
 
 if ($EmacsCommand) {
   if (Test-EmacsExe -ErrorAction Stop) {

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ software.
 # ChangeLog
 
 
+## Master
+
+-   `Get-Command` call in install wizard is now silent when Emacs isn't installed
+
+
 ## 2020-05-11 Release v0.1.1
 
 -   Copy edits to the introduction


### PR DESCRIPTION
Addresses #7. Tested locally be editing the output install wizard to check for a different nonexistent exe. Hard to fully test without removing Emacs from my system but looks good.