### PR TITLE
Quote the module path in Invoke-AsAdministrator call to support paths with spaces

### DIFF
--- a/Cackledaemon.org
+++ b/Cackledaemon.org
@@ -2826,7 +2826,7 @@ function Install-Emacs {
     Invoke-AsAdministrator "
       `$ErrorActionPreference = 'Stop'
 
-      Import-Module $ModulePath
+      Import-Module `"$ModulePath`"
 
       Write-Progress -Id 1 -Activity 'Installing Emacs' -CurrentOperation 'Updating Emacs...' -PercentComplete 63
       Write-CDInfo 'Updating Emacs...'
@@ -3930,6 +3930,8 @@ task Publish Build, Test, {
 #+END_SRC
 
 * ChangeLog :export:
+** Master
+- Quote module path to support paths with spaces in them
 ** 2020-05-14 Release v0.1.2
 - ~Get-Command~ call in install wizard is now silent when Emacs isn't installed
 - Ensure PSeudo is at least version 1.0 in manifest

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ software.
 # ChangeLog
 
 
+## Master
+
+-   Quote module path to support paths with spaces in them
+
+
 ## 2020-05-14 Release v0.1.2
 
 -   `Get-Command` call in install wizard is now silent when Emacs isn't installed


### PR DESCRIPTION
Fixes #10.

The reason I haven't triggered this is because when I was testing I was using a user-scoped module with a username with no spaces, meaning the path was `C:\Users\Josh\Documents\WindowsPowerShell\Modules\Cackledaemon\v0.1.1` with no spaces. If a user has a space in their username, or the path is coming from a different place (it seems for some users that installed as administrator that it installed the module in Program Files) this can cause problems.