### PR TITLE
Create start menu directory when installing applet shortcuts

### DIFF
--- a/Cackledaemon.org
+++ b/Cackledaemon.org
@@ -3813,7 +3813,6 @@ Describe 'Install-CDApplet' {
       New-Item -Type Directory 'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs'
     }
 
-
     It 'installs applet shortcuts' {
       Install-CDApplet
 

--- a/Cackledaemon.org
+++ b/Cackledaemon.org
@@ -3777,6 +3777,10 @@ launch on user login.
 function Install-CDApplet {
   . $CackledaemonConfigLocation
 
+  if (-not (Test-Path $StartMenuPath)) {
+    New-Item -Type Directory $StartMenuPath
+  }
+
   $StartupPath = Join-Path $Env:AppData 'Microsoft\Windows\Start Menu\Programs\Startup'
 
   @($StartMenuPath, $StartupPath) | ForEach-Object {

--- a/Cackledaemon.org
+++ b/Cackledaemon.org
@@ -3797,7 +3797,6 @@ directory is non-configurable.
 Describe 'Install-CDApplet' {
   BeforeEach {
     Initialize-TestEnvironment
-    New-Item -Type Directory 'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs'
     New-Item -Type Directory 'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Startup'
   }
 
@@ -3805,11 +3804,27 @@ Describe 'Install-CDApplet' {
     Restore-StandardEnvironment
   }
 
-  It 'installs applet shortcuts' {
-    Install-CDApplet
+  Context 'when the shortcuts directory exists' {
+    BeforeEach {
+      New-Item -Type Directory 'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs'
+    }
 
-    'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs\Cackledaemon.lnk' | Should -Exist
-    'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Startup\Cackledaemon.lnk' | Should -Exist
+
+    It 'installs applet shortcuts' {
+      Install-CDApplet
+
+      'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs\Cackledaemon.lnk' | Should -Exist
+      'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Startup\Cackledaemon.lnk' | Should -Exist
+    }
+  }
+
+  Context "when the shortcuts directory doesn't exist" {
+    It 'installs the applet shorcuts' {
+      Install-CDApplet
+
+      'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Gnu Emacs\Cackledaemon.lnk' | Should -Exist
+      'TestDrive:\AppData\Microsoft\Windows\Start Menu\Programs\Startup\Cackledaemon.lnk' | Should -Exist
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #21. The prior fix didn't handle creating the directory during the install of the Cackledaemon applet shortcut, so if there were no shortcuts configured *and* the directory didn't exist then it would still crash.

There might be a use case for disabling the creation of shortcuts in general, but that would be a new feature.